### PR TITLE
Added a rate limiter

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -15,6 +15,7 @@
         "cors": "^2.8.5",
         "dotenv": "^16.4.7",
         "express": "^4.21.2",
+        "express-rate-limit": "^7.5.0",
         "jsonwebtoken": "^9.0.2",
         "mongoose": "^8.10.1"
       },
@@ -2573,6 +2574,20 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.0.tgz",
+      "integrity": "sha512-eB5zbQh5h+VenMPM3fh+nw1YExi5nMr6HUCR62ELSP11huvxm/Uir1H1QEyTkk5QX6A58pX6NmaTMceKZ0Eodg==",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": "^4.11 || 5 || ^5.0.0-beta.1"
       }
     },
     "node_modules/fast-fifo": {
@@ -7442,6 +7457,7 @@
         "cors": "^2.8.5",
         "dotenv": "^16.4.7",
         "express": "^4.21.2",
+        "express-rate-limit": "^7.5.0",
         "jest": "^29.7.0",
         "jsonwebtoken": "^9.0.2",
         "mongodb-memory-server": "^10.1.4",
@@ -9273,6 +9289,12 @@
             "utils-merge": "1.0.1",
             "vary": "~1.1.2"
           }
+        },
+        "express-rate-limit": {
+          "version": "7.5.0",
+          "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.0.tgz",
+          "integrity": "sha512-eB5zbQh5h+VenMPM3fh+nw1YExi5nMr6HUCR62ELSP11huvxm/Uir1H1QEyTkk5QX6A58pX6NmaTMceKZ0Eodg==",
+          "requires": {}
         },
         "fast-fifo": {
           "version": "1.3.2",
@@ -12292,6 +12314,12 @@
         "utils-merge": "1.0.1",
         "vary": "~1.1.2"
       }
+    },
+    "express-rate-limit": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.0.tgz",
+      "integrity": "sha512-eB5zbQh5h+VenMPM3fh+nw1YExi5nMr6HUCR62ELSP11huvxm/Uir1H1QEyTkk5QX6A58pX6NmaTMceKZ0Eodg==",
+      "requires": {}
     },
     "fast-fifo": {
       "version": "1.3.2",

--- a/backend/package.json
+++ b/backend/package.json
@@ -4,7 +4,7 @@
   "main": "server.js",
   "scripts": {
     "build": "tsc",
-    "test" : "jest",
+    "test": "jest",
     "start": "node dist/server.js",
     "build and start": "tsc && node dist/server.js",
     "build and test": "tsc && jest"
@@ -21,7 +21,8 @@
     "dotenv": "^16.4.7",
     "express": "^4.21.2",
     "jsonwebtoken": "^9.0.2",
-    "mongoose": "^8.10.1"
+    "mongoose": "^8.10.1",
+    "express-rate-limit": "^7.5.0"
   },
   "devDependencies": {
     "@types/bcrypt": "^5.0.2",

--- a/backend/src/routes/dashboardRoutes.ts
+++ b/backend/src/routes/dashboardRoutes.ts
@@ -3,16 +3,8 @@ import DashboardController from '../controllers/dashboardController';
 import { checkChannelPermission, checkTeamPermission, checkUserPermission } from '../middlewares/permissionMiddleware';
 import authenticate from '../middlewares/authMiddleware';
 import { Role, TeamRole } from '../enums';
-import rateLimit from 'express-rate-limit';
 
 const dashboardRoutes = Router();
-
-const limiter = rateLimit({
-  windowMs: 15 * 60 * 1000, // 15 minutes
-  max: 100, // max 100 requests per windowMs
-});
-
-dashboardRoutes.use(limiter);
 
 dashboardRoutes.get('/listTeams', authenticate, DashboardController.listTeams);
 dashboardRoutes.get('/listChannels', authenticate, checkTeamPermission(TeamRole.MEMBER), DashboardController.listChannels);

--- a/backend/src/routes/dashboardRoutes.ts
+++ b/backend/src/routes/dashboardRoutes.ts
@@ -3,8 +3,16 @@ import DashboardController from '../controllers/dashboardController';
 import { checkChannelPermission, checkTeamPermission, checkUserPermission } from '../middlewares/permissionMiddleware';
 import authenticate from '../middlewares/authMiddleware';
 import { Role, TeamRole } from '../enums';
+import rateLimit from 'express-rate-limit';
 
 const dashboardRoutes = Router();
+
+const limiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // max 100 requests per windowMs
+});
+
+dashboardRoutes.use(limiter);
 
 dashboardRoutes.get('/listTeams', authenticate, DashboardController.listTeams);
 dashboardRoutes.get('/listChannels', authenticate, checkTeamPermission(TeamRole.MEMBER), DashboardController.listChannels);

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -9,6 +9,7 @@ import channelRoutes from './routes/channelRoutes';
 import superAdminRoutes from './routes/superAdminRoutes';
 import dashboardRoutes from './routes/dashboardRoutes';
 import path from 'path';
+import rateLimit from 'express-rate-limit';
 
 const MONGO_URI = process.env.MONGO_URI || 'mongodb://127.0.0.1:27017/chathavendb';
 
@@ -23,6 +24,13 @@ const backend = express();
 backend.use(express.json());
 backend.use(cors());
 backend.use(express.static(path.join(__dirname, '../', '../', './frontend', './build')));
+
+const limiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: 100,
+});
+
+backend.use(limiter);
 
 backend.use('/user', userRoutes);
 backend.use('/channel', channelRoutes);


### PR DESCRIPTION
This pull request includes the addition of the `express-rate-limit` package to the project and its integration into the server setup to enhance security by limiting repeated requests to public APIs and endpoints. The most important changes are listed below:

Dependency additions:
* [`backend/package-lock.json`](diffhunk://#diff-f89763fc11c1bc48ac3c7ce8a148fbbbc5c2062393ee78664a70273d714daf5cR18): Added `express-rate-limit` version `7.5.0` with its integrity, resolved URL, and peer dependencies. [[1]](diffhunk://#diff-f89763fc11c1bc48ac3c7ce8a148fbbbc5c2062393ee78664a70273d714daf5cR18) [[2]](diffhunk://#diff-f89763fc11c1bc48ac3c7ce8a148fbbbc5c2062393ee78664a70273d714daf5cR2579-R2592) [[3]](diffhunk://#diff-f89763fc11c1bc48ac3c7ce8a148fbbbc5c2062393ee78664a70273d714daf5cR7460) [[4]](diffhunk://#diff-f89763fc11c1bc48ac3c7ce8a148fbbbc5c2062393ee78664a70273d714daf5cR9293-R9298) [[5]](diffhunk://#diff-f89763fc11c1bc48ac3c7ce8a148fbbbc5c2062393ee78664a70273d714daf5cR12318-R12323)
* [`backend/package.json`](diffhunk://#diff-495707834ca4b862f9acdfbac70d279023d2c059da13db59594e61ed3354fed5L24-R25): Added `express-rate-limit` version `7.5.0` to the dependencies.

Server setup:
* [`backend/src/server.ts`](diffhunk://#diff-03830d1462a5acd300db5f366d82d5232c32ff001e382f55d3cca74a65be60aaR12): Imported `express-rate-limit` and configured it with a limit of 100 requests per 15 minutes window. Applied this rate limiter to the entire backend application. [[1]](diffhunk://#diff-03830d1462a5acd300db5f366d82d5232c32ff001e382f55d3cca74a65be60aaR12) [[2]](diffhunk://#diff-03830d1462a5acd300db5f366d82d5232c32ff001e382f55d3cca74a65be60aaR28-R34)