### PR TITLE
Add setSelectedTeamMembers prop to TeamList and ChannelList components

### DIFF
--- a/frontend/src/Components/ChannelList.tsx
+++ b/frontend/src/Components/ChannelList.tsx
@@ -60,12 +60,17 @@ const ChannelList: React.FC<ChannelListProps> = ({selectedUsers, setSelectedUser
       prevSelectedChannel === channel ? null : channel
     );
     setSelectedUsers([]);
+    setSelectedTeamMembers([]);
   };
+
+  if (!selectedTeam) {
+    return null;
+  }
 
   return (
     <div style={styles.channelList}>
       <h3 onClick={() => setCollapsed(!collapsed)} style={styles.listHeader}>
-        Channels {collapsed ? "▲" : "▼"}
+        {selectedTeam ? `Channels for ${selectedTeam}` : "Channels"} {collapsed ? "▲" : "▼"}
       </h3>
       {!collapsed && (
         <ul style={styles.listContainer}>

--- a/frontend/src/Components/TeamList.tsx
+++ b/frontend/src/Components/TeamList.tsx
@@ -20,9 +20,10 @@ interface TeamListProps {
   setSelectedTeam: React.Dispatch<React.SetStateAction<string | null>>;
   selectedChannel: string | null;
   setSelectedChannel: React.Dispatch<React.SetStateAction<string | null>>;
+  setSelectedTeamMembers: React.Dispatch<React.SetStateAction<string[]>>;
 }
 
-const TeamList: React.FC<TeamListProps> = ({selectedUsers, setSelectedUsers, selectedTeam, setSelectedTeam, selectedChannel, setSelectedChannel}) => {
+const TeamList: React.FC<TeamListProps> = ({selectedUsers, setSelectedUsers, selectedTeam, setSelectedTeam, selectedChannel, setSelectedChannel, setSelectedTeamMembers}) => {
   const [collapsed, setCollapsed] = useState(false);
   const [teams, setTeams] = useState<Team[]>([]);
   const navigate = useNavigate();
@@ -58,6 +59,7 @@ const TeamList: React.FC<TeamListProps> = ({selectedUsers, setSelectedUsers, sel
     );
     setSelectedUsers([]);
     setSelectedChannel(null);
+    setSelectedTeamMembers([]);
   };
 
   return (

--- a/frontend/src/Pages/AdminDashboard.tsx
+++ b/frontend/src/Pages/AdminDashboard.tsx
@@ -95,6 +95,7 @@ const AdminDashboard: React.FC = () => {
             setSelectedTeam={setSelectedTeam} 
             selectedChannel={selectedChannel} 
             setSelectedChannel={setSelectedChannel}
+            setSelectedTeamMembers={setSelectedTeamMembers}
           />
           <ChannelList
             selectedUsers={selectedUsers} 


### PR DESCRIPTION
This pull request includes updates to the `ChannelList`, `TeamList`, and `AdminDashboard` components to improve the handling of team members and selected teams.

Changes to improve team member handling:

* [`frontend/src/Components/ChannelList.tsx`](diffhunk://#diff-f47461125d7909dd67d12b5d5facf33c908da13b209325d55683293433fe1fb1R63-R73): Added `setSelectedTeamMembers` to reset team members when a new channel is selected and added a check to return null if no team is selected.
* [`frontend/src/Components/TeamList.tsx`](diffhunk://#diff-699908aceae71750d2f832a7f76c7eef9f088afd9555f0fe136e4fa8b409ac09R23-R26): Added `setSelectedTeamMembers` to the `TeamListProps` interface and updated the component to reset team members when a new team is selected. [[1]](diffhunk://#diff-699908aceae71750d2f832a7f76c7eef9f088afd9555f0fe136e4fa8b409ac09R23-R26) [[2]](diffhunk://#diff-699908aceae71750d2f832a7f76c7eef9f088afd9555f0fe136e4fa8b409ac09R62)
* [`frontend/src/Pages/AdminDashboard.tsx`](diffhunk://#diff-2bc287c9844e014ef9e4009f0514b00f57ef3166f8f3fe4870800b1fe373dfecR98): Passed `setSelectedTeamMembers` prop to `TeamList` component.