### PR TITLE
Rename DirectMessages component to TeamMessages 

### DIFF
--- a/frontend/src/Components/DirectMessages.tsx
+++ b/frontend/src/Components/DirectMessages.tsx
@@ -9,12 +9,12 @@ interface chatMessage {
   createdAt: Date;
 }
 
-interface DirectMessagesProps {
+interface TeamChannelProps {
   selectedTeam: string | null;
   selectedChannel: string | null;
 }
 
-const DirectMessages: React.FC<DirectMessagesProps> = ({ selectedTeam, selectedChannel }) => {
+const TeamMessages: React.FC<TeamChannelProps> = ({ selectedTeam, selectedChannel }) => {
   const [messages, setMessages] = useState<chatMessage[]>([]);
   const [message, setMessage] = useState<string>("");
   const ws = useRef<WebSocket | null>(null);
@@ -86,7 +86,7 @@ const DirectMessages: React.FC<DirectMessagesProps> = ({ selectedTeam, selectedC
   }, [selectedChannel, selectedTeam]);
 
   return (
-    <div style={styles.directMessages}>
+    <div style={styles.teamMessages}>
       <div style={styles.chatHeader}>Direct Messages</div>
       <div style={styles.chatBox}>
         {messages.length === 0 ? (
@@ -124,4 +124,4 @@ const DirectMessages: React.FC<DirectMessagesProps> = ({ selectedTeam, selectedC
   );
 };
 
-export default DirectMessages;
+export default TeamMessages;

--- a/frontend/src/Pages/AdminDashboard.tsx
+++ b/frontend/src/Pages/AdminDashboard.tsx
@@ -3,7 +3,7 @@ import { useNavigate } from "react-router-dom";
 import UserList from "../Components/userList";
 import TeamList from "../Components/TeamList";
 import ChannelList from "../Components/ChannelList";
-import DirectMessages from "../Components/DirectMessages";
+import TeamMessages from "../Components/DirectMessages";
 import AddUserToTeam from "../Components/AddUserToTeam";
 import styles from "../Styles/dashboardStyles";
 import TeamMemberList from "../Components/teamMemberList";
@@ -109,7 +109,7 @@ const AdminDashboard: React.FC = () => {
           />
         </div>
         
-        <DirectMessages 
+        <TeamMessages 
           selectedTeam={selectedTeam} 
           selectedChannel={selectedChannel}
         />

--- a/frontend/src/Styles/dashboardStyles.ts
+++ b/frontend/src/Styles/dashboardStyles.ts
@@ -83,7 +83,7 @@ const styles = {
     width: "35%",
     gap: "10px",
   },
-  directMessages: {
+  teamMessages: {
     width: "40%",
     height: "74%",
     padding: "15px",


### PR DESCRIPTION
This pull request includes changes to rename the `DirectMessages` component to `TeamMessages` across multiple files for consistency and clarity. The most important changes include updating the component name, associated props, and styles.

Component renaming:

* [`frontend/src/Components/DirectMessages.tsx`](diffhunk://#diff-592a95f853ce1f476f53f2ee8b721d9ba17bda26dc37ab0d29718c3ceacf5b9fL12-R17): Renamed the `DirectMessages` component to `TeamMessages` and updated the associated props from `DirectMessagesProps` to `TeamChannelProps`. [[1]](diffhunk://#diff-592a95f853ce1f476f53f2ee8b721d9ba17bda26dc37ab0d29718c3ceacf5b9fL12-R17) [[2]](diffhunk://#diff-592a95f853ce1f476f53f2ee8b721d9ba17bda26dc37ab0d29718c3ceacf5b9fL89-R89) [[3]](diffhunk://#diff-592a95f853ce1f476f53f2ee8b721d9ba17bda26dc37ab0d29718c3ceacf5b9fL127-R127)

Import and usage updates:

* [`frontend/src/Pages/AdminDashboard.tsx`](diffhunk://#diff-2bc287c9844e014ef9e4009f0514b00f57ef3166f8f3fe4870800b1fe373dfecL6-R6): Updated the import and usage of the renamed `TeamMessages` component. [[1]](diffhunk://#diff-2bc287c9844e014ef9e4009f0514b00f57ef3166f8f3fe4870800b1fe373dfecL6-R6) [[2]](diffhunk://#diff-2bc287c9844e014ef9e4009f0514b00f57ef3166f8f3fe4870800b1fe373dfecL112-R112)

Style updates:

* [`frontend/src/Styles/dashboardStyles.ts`](diffhunk://#diff-82b086bdabc90f100362943a07e93964ea5d35d060340fc4439b2fea2445f653L86-R86): Renamed the `directMessages` style to `teamMessages` to reflect the component name change.