### PR TITLE
Add .npmrc file to enable legacy peer dependencies

### DIFF
--- a/frontend/.npmrc
+++ b/frontend/.npmrc
@@ -1,0 +1,1 @@
+legacy-peer-deps=true


### PR DESCRIPTION
This pull request includes a small change to the `frontend/.npmrc` file. The change enables the `legacy-peer-deps` setting to ensure compatibility with older packages.