### PR TITLE
Update package.json and yarn.lock for dependency version consistency

### DIFF
--- a/ChatHavenApp/frontend/package.json
+++ b/ChatHavenApp/frontend/package.json
@@ -14,7 +14,7 @@
     "react-dom": "^19.0.0",
     "react-icons": "^5.5.0",
     "react-router-dom": "^7.4.0",
-    "react-scripts": "^5.0.1",
+    "react-scripts": "5.0.1",
     "whatwg-fetch": "^3.6.20"
   },
   "scripts": {
@@ -45,6 +45,7 @@
     "node": ">=18.0.0"
   },
   "devDependencies": {
+    "@babel/core": "^7.26.10",
     "@babel/plugin-syntax-flow": "^7.14.5",
     "@babel/plugin-transform-react-jsx": "^7.14.9",
     "@testing-library/jest-dom": "^6.6.3",
@@ -63,7 +64,7 @@
     "jest-environment-jsdom": "^29.7.0",
     "jest-mock-extended": "3.0.7",
     "jest-sonar-reporter": "2.0.0",
-    "jest-watch-typeahead": "^2.2.2",
+    "jest-watch-typeahead": "2.2.2",
     "node-fetch": "3.3.2",
     "ts-jest": "^29.3.0",
     "typescript": "^5.8.2"

--- a/ChatHavenApp/package.json
+++ b/ChatHavenApp/package.json
@@ -16,8 +16,7 @@
     "type-check": "turbo run type-check",
     "format": "prettier --write \"**/*.{ts,tsx,js,jsx,json,md}\"",
     "clean": "turbo run clean && rimraf node_modules .turbo",
-    "prepare": "cd .. && husky install ChatHavenApp/.husky",
-    "install": "yarn install"
+    "prepare": "cd .. && husky install ChatHavenApp/.husky"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^5.62.0",

--- a/ChatHavenApp/yarn.lock
+++ b/ChatHavenApp/yarn.lock
@@ -43,7 +43,7 @@
   resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.26.8.tgz#821c1d35641c355284d4a870b8a4a7b0c141e367"
   integrity sha512-oH5UPLMWR3L2wEFLnFJ1TZXqHufiTKAiLfqw5zkhS4dKXLJ10yVztfil/twG8EDTA4F/tvVNw9nOl4ZMslB8rQ==
 
-"@babel/core@^7.1.0", "@babel/core@^7.11.1", "@babel/core@^7.11.6", "@babel/core@^7.12.3", "@babel/core@^7.16.0", "@babel/core@^7.23.9":
+"@babel/core@^7.1.0", "@babel/core@^7.11.1", "@babel/core@^7.11.6", "@babel/core@^7.12.3", "@babel/core@^7.16.0", "@babel/core@^7.23.9", "@babel/core@^7.26.10":
   version "7.26.10"
   resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.26.10.tgz#5c876f83c8c4dcb233ee4b670c0606f2ac3000f9"
   integrity sha512-vMqyb7XCDMPvJFFOaT9kxtiRh42GwlZEg1/uIgtZshS5a/8OaduUfCi7kynKgc3Tw/6Uo2D+db9qBttghhmxwQ==
@@ -6826,6 +6826,19 @@ jest-validate@^29.7.0:
     leven "^3.1.0"
     pretty-format "^29.7.0"
 
+jest-watch-typeahead@2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/jest-watch-typeahead/-/jest-watch-typeahead-2.2.2.tgz#5516d3cd006485caa5cfc9bd1de40f1f8b136abf"
+  integrity sha512-+QgOFW4o5Xlgd6jGS5X37i08tuuXNW8X0CV9WNFi+3n8ExCIP+E1melYhvYLjv5fE6D0yyzk74vsSO8I6GqtvQ==
+  dependencies:
+    ansi-escapes "^6.0.0"
+    chalk "^5.2.0"
+    jest-regex-util "^29.0.0"
+    jest-watcher "^29.0.0"
+    slash "^5.0.0"
+    string-length "^5.0.1"
+    strip-ansi "^7.0.1"
+
 jest-watch-typeahead@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/jest-watch-typeahead/-/jest-watch-typeahead-1.1.0.tgz#b4a6826dfb9c9420da2f7bc900de59dad11266a9"
@@ -6836,19 +6849,6 @@ jest-watch-typeahead@^1.0.0:
     jest-regex-util "^28.0.0"
     jest-watcher "^28.0.0"
     slash "^4.0.0"
-    string-length "^5.0.1"
-    strip-ansi "^7.0.1"
-
-jest-watch-typeahead@^2.2.2:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/jest-watch-typeahead/-/jest-watch-typeahead-2.2.2.tgz#5516d3cd006485caa5cfc9bd1de40f1f8b136abf"
-  integrity sha512-+QgOFW4o5Xlgd6jGS5X37i08tuuXNW8X0CV9WNFi+3n8ExCIP+E1melYhvYLjv5fE6D0yyzk74vsSO8I6GqtvQ==
-  dependencies:
-    ansi-escapes "^6.0.0"
-    chalk "^5.2.0"
-    jest-regex-util "^29.0.0"
-    jest-watcher "^29.0.0"
-    slash "^5.0.0"
     string-length "^5.0.1"
     strip-ansi "^7.0.1"
 
@@ -9091,7 +9091,7 @@ react-router@7.5.0:
     set-cookie-parser "^2.6.0"
     turbo-stream "2.4.0"
 
-react-scripts@^5.0.1:
+react-scripts@5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/react-scripts/-/react-scripts-5.0.1.tgz#6285dbd65a8ba6e49ca8d651ce30645a6d980003"
   integrity sha512-8VAmEm/ZAwQzJ+GOMLbBsTdDKOpuZh7RPs0UymvBR2vRk4iZWCskjbFnxqjrzoIvlNNRZ3QJFx6/qDSi6zSnaQ==


### PR DESCRIPTION
This pull request includes updates to the `ChatHavenApp` project, focusing on dependency version adjustments and script modifications. The most important changes include updating dependencies in `package.json` files and modifying the `prepare` and `install` scripts.

Dependency updates:

* [`ChatHavenApp/frontend/package.json`](diffhunk://#diff-db4234ebcf596c0455c3a21bc00a4262ebd26abbb686bfc6ae00d3ae49fbe8ceL17-R17): Changed the version specification of `react-scripts` and `jest-watch-typeahead` from using a caret (^) to fixed versions. Added `@babel/core` to devDependencies. [[1]](diffhunk://#diff-db4234ebcf596c0455c3a21bc00a4262ebd26abbb686bfc6ae00d3ae49fbe8ceL17-R17) [[2]](diffhunk://#diff-db4234ebcf596c0455c3a21bc00a4262ebd26abbb686bfc6ae00d3ae49fbe8ceR48) [[3]](diffhunk://#diff-db4234ebcf596c0455c3a21bc00a4262ebd26abbb686bfc6ae00d3ae49fbe8ceL66-R67)

Script modifications:

* [`ChatHavenApp/package.json`](diffhunk://#diff-98455a15c8d120458db52f0cf5b48f12f3ef41186f62efd4171353189e602384L19-R19): Removed the `install` script and updated the `prepare` script.