### PR TITLE
Add space after username in MessageItem component

### DIFF
--- a/ChatHavenApp/frontend/src/Components/Messaging/components/MessageItem.tsx
+++ b/ChatHavenApp/frontend/src/Components/Messaging/components/MessageItem.tsx
@@ -83,7 +83,7 @@ const MessageItem: React.FC<MessageItemProps> = ({
             aria-label={`Message from ${message.username}`}
         >
             <div>
-                <strong>{message.username}</strong>
+                <strong>{message.username}</strong>&nbsp;
 
                 {/* Render quoted message if it exists */}
                 {message.quotedMessage && (


### PR DESCRIPTION
This pull request includes a small change to the `ChatHavenApp/frontend/src/Components/Messaging/components/MessageItem.tsx` file. The change adds a non-breaking space (`&nbsp;`) after the username to improve the formatting of messages.

* [`ChatHavenApp/frontend/src/Components/Messaging/components/MessageItem.tsx`](diffhunk://#diff-bd9efce0e9b3f640d429451e290f19733a198bfa2995b87bdfe773b2194d80e1L86-R86): Added a non-breaking space after the `message.username` to ensure proper spacing in the message display.